### PR TITLE
GF2023

### DIFF
--- a/Bestyrelse.md
+++ b/Bestyrelse.md
@@ -13,32 +13,29 @@
  
 | Navn   |  IRC-nick | År senest valgt | År på valg igen |
 |--------|:---------:|:---------------:|:---------------:|
-|Nicky Thomassen | nicky | 2021 | 2023|
+|Dennis Krogh | Mantise | 2023 | 2025|
 
  
  * Bestyrelsesmedlemmer (2-4 kandidater i lige år og 1-3 kandidater i ulige år) 
  
 | Navn   |  IRC-nick | År senest valgt | År på valg igen |
 |--------|:---------:|:---------------:|:---------------:|
-|Nicky Thomassen | nicky | 2021 | 2023|
 |Anders Jenbo | Ajenbo|2022|2024|
 | Jannie Udengaard | Momsemor | 2022 | 2024|
+|Dennis Krogh | Mantise | 2023 | 2025|
+|Daniel Ejsing-Duun | Zilvador|2023|2025|
 
-
- 
  * Op til 2 suppleanter
  
  (ingen)
 
 * Revisor (ikke bestyrelsesmedlem)
  
-| Navn   |  IRC-nick | År senest valgt | År på valg igen |
-|--------|:---------:|:---------------:|:---------------:|
-|HenningBuddig |  buddig | 2022 | 2023|
+(ingen)
 
  * LoCo-kontakt (kan godt være et bestyrelsesmedlem)
  
 | Navn   |  IRC-nick | År senest valgt | År på valg igen |
 |--------|:---------:|:---------------:|:---------------:|
-|Daniel Ejsing-Duun | Zilvador|2022|2023|
+|Daniel Ejsing-Duun | Zilvador|2023|2024|
  

--- a/Generalforsamlinger.md
+++ b/Generalforsamlinger.md
@@ -1,3 +1,8 @@
+## Dato 2023-06-08
+- [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2023-June/003039.html)
+- [Referat](https://lists.ubuntu.com/archives/ubuntu-dk/2023-August/003040.html)
+- [Discord log](LINK HER?!?)
+
 ## Dato 2022-05-24
 - [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2022-April/003034.html)
 - [Referat](https://lists.ubuntu.com/archives/ubuntu-dk/2022-July/003037.html)

--- a/Generalforsamlinger.md
+++ b/Generalforsamlinger.md
@@ -1,7 +1,7 @@
 ## Dato 2023-06-08
 - [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2023-June/003039.html)
 - [Referat](https://lists.ubuntu.com/archives/ubuntu-dk/2023-August/003040.html)
-- [Discord log](LINK HER?!?)
+- [Discord log](https://discord.com/channels/847917317626658916/847918205283598368/1116433941012959414)
 
 ## Dato 2022-05-24
 - [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2022-April/003034.html)


### PR DESCRIPTION
Opdateret oversigt over bestyrelsen (efter valget), og tilføjet links til referat, indkaldelse og discord-log for generalforsamlingen 2023.