### PR TITLE
Update Generalforsamling 2024

### DIFF
--- a/Generalforsamlinger.md
+++ b/Generalforsamlinger.md
@@ -1,3 +1,8 @@
+## Dato 2024-05-14
+- [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2024-April/003041.html)
+- [Referat](MANGLER)
+- [Discord log](MANGLER)
+
 ## Dato 2023-06-08
 - [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2023-June/003039.html)
 - [Referat](https://lists.ubuntu.com/archives/ubuntu-dk/2023-August/003040.html)


### PR DESCRIPTION
Tilføjet 2024

Efter Generalforsamling 14. maj skal også opdateres bestyrelsesoversigt, referat og log.


Derefter kan denne merges.

