### PR TITLE
GF 2025

### DIFF
--- a/Bestyrelse.md
+++ b/Bestyrelse.md
@@ -13,7 +13,7 @@
  
 | Navn   |  IRC-nick | År senest valgt | År på valg igen |
 |--------|:---------:|:---------------:|:---------------:|
-|Dennis Krogh | Mantise | 2023 | 2025|
+|Dennis Krogh | Mantise | 2025 | 2027|
 
  
  * Bestyrelsesmedlemmer (2-4 kandidater i lige år og 1-3 kandidater i ulige år) 
@@ -21,9 +21,9 @@
 | Navn   |  IRC-nick | År senest valgt | År på valg igen |
 |--------|:---------:|:---------------:|:---------------:|
 |Anders Jenbo | Ajenbo|2024|2026|
-| Jannie Udengaard | Momsemor | 2024 | 2026|
-|Dennis Krogh | Mantise | 2023 | 2025|
-|Daniel Ejsing-Duun | Zilvador|2023|2025|
+|Jannie Udengaard | Momsemor | 2024 | 2026|
+|Dennis Krogh | Mantise | 2025 | 2027|
+|Daniel Ejsing-Duun | Zilvador|2025|2027|
 
  * Op til 2 suppleanter
  
@@ -37,5 +37,5 @@
  
 | Navn   |  IRC-nick | År senest valgt | År på valg igen |
 |--------|:---------:|:---------------:|:---------------:|
-|Daniel Ejsing-Duun | Zilvador|2024|2026|
+|Daniel Ejsing-Duun | Zilvador|2025|2026|
  

--- a/Generalforsamlinger.md
+++ b/Generalforsamlinger.md
@@ -1,3 +1,6 @@
+## Dato 2025-05-27
+- [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2025-March/003044.html)
+
 ## Dato 2024-05-14
 - [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2024-April/003041.html)
 - [Referat](MANGLER)

--- a/Generalforsamlinger.md
+++ b/Generalforsamlinger.md
@@ -1,6 +1,6 @@
 ## Dato 2025-05-27
 - [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2025-March/003044.html)
-- [Referat](OPDATERES SENERE)
+- [Referat](https://lists.ubuntu.com/archives/ubuntu-dk/2025-June/003051.html)
 - [Discord log](https://discord.com/channels/847917317626658916/847918205283598368/1376998660058910840)
 
 ## Dato 2024-05-14

--- a/Generalforsamlinger.md
+++ b/Generalforsamlinger.md
@@ -1,5 +1,7 @@
 ## Dato 2025-05-27
 - [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2025-March/003044.html)
+- [Referat](OPDATERES SENERE)
+- [Discord log](https://discord.com/channels/847917317626658916/847918205283598368/1376998660058910840)
 
 ## Dato 2024-05-14
 - [Indkaldelse](https://lists.ubuntu.com/archives/ubuntu-dk/2024-April/003041.html)


### PR DESCRIPTION
Opdateret bestyrelses-oversigt efter 2025 generalforsamling.
Tilføjet links til indkaldelse, referat og discord-log af 2025 generalforsamling.